### PR TITLE
Upgrade SQLite

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="eric.poe@gmail.com"
 # Set TERM environment var - so terminal cmds like `top` work
 ENV TERM=xterm
 
-RUN yum install -y wget epel-release \
+RUN yum install -y epel-release \
         http://rpms.famillecollet.com/enterprise/remi-release-6.rpm \
         http://repo.okay.com.mx/centos/6/x86_64/release/okay-release-1-1.noarch.rpm \
         && \

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -5,11 +5,14 @@ LABEL maintainer="eric.poe@gmail.com"
 # Set TERM environment var - so terminal cmds like `top` work
 ENV TERM=xterm
 
-RUN yum install -y wget epel-release
-RUN wget http://rpms.famillecollet.com/enterprise/remi-release-6.rpm
-RUN rpm -Uvh remi-release-6*.rpm
-RUN yum update -y
-RUN yum --enablerepo=remi-php71 install -y \
+RUN yum install -y wget epel-release \
+        http://rpms.famillecollet.com/enterprise/remi-release-6.rpm \
+        http://repo.okay.com.mx/centos/6/x86_64/release/okay-release-1-1.noarch.rpm \
+        && \
+    yum clean all
+
+RUN yum update -y \
+    && yum --enablerepo=remi-php71 install -y \
         git \
         php \
         php-bcmath \


### PR DESCRIPTION
This will add the OKey rpm repo so that we can upgrade SQLite due to a bug that was fixed in 3.6.22 (#1 in https://sqlite.org/releaselog/3_6_22.html). This was causing tests to fail.

I also optimized the Dockerfile to create fewer and smaller image layers