### PR TITLE
Upgrade to CentOS 7

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,7 +1,5 @@
 FROM centos:7
 
-LABEL maintainer="eric.poe@gmail.com"
-
 # Set TERM environment var - so terminal cmds like `top` work
 ENV TERM=xterm
 

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -9,7 +9,8 @@ RUN yum install -y epel-release \
     yum clean all
 
 RUN yum update -y \
-    && yum --enablerepo=remi-php71 install -y \
+    && \
+    yum --enablerepo=remi-php71 install -y \
         git \
         php \
         php-bcmath \

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -5,7 +5,6 @@ ENV TERM=xterm
 
 RUN yum install -y epel-release \
         http://rpms.famillecollet.com/enterprise/remi-release-7.rpm \
-        http://repo.okay.com.mx/centos/7/x86_64/release/okay-release-1-1.noarch.rpm \
         && \
     yum clean all
 

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,14 +1,13 @@
-FROM centos:6
+FROM centos:7
 
 LABEL maintainer="eric.poe@gmail.com"
 
 # Set TERM environment var - so terminal cmds like `top` work
 ENV TERM=xterm
 
-RUN find /etc/yum.repos.d/*.repo | xargs -i sed -i 's/mirror\.centos\.org\/centos/vault.centos.org/g;s/$releasever/6.10/g;s/mirrorlist/#mirrorlist/g;s/#baseurl/baseurl/g;s/download\.fedoraproject\.org\/pub\/epel/archives.fedoraproject.org\/pub\/archive\/epel/g' {} \
-    && yum install -y epel-release \
-        http://rpms.famillecollet.com/enterprise/remi-release-6.rpm \
-        http://repo.okay.com.mx/centos/6/x86_64/release/okay-release-1-1.noarch.rpm \
+RUN yum install -y epel-release \
+        http://rpms.famillecollet.com/enterprise/remi-release-7.rpm \
+        http://repo.okay.com.mx/centos/7/x86_64/release/okay-release-1-1.noarch.rpm \
         && \
     yum clean all
 


### PR DESCRIPTION
We will be upgrading our production server to CentOS 7 soon, so this change allows us to test in that environment.

This brings our version of OpenSSH to one that allows us to take advantage of newer features in our dev environment like `AddKeysToAgent` in `~/.ssh/config` (v 7.4, available since v7.2)

Changes:
* Remove archive vault repo since CentOS 7 is not EOL
* Remove "okay" repo since CentOS 7 has the same version of sqlite3 that repo provides
* Remove "maintainer" label because this is a team effort and github keeps track of who maintains this project.
* Align text on "yum" commands
* Alpha-sort installed packages (I think the vscode docker plugin did this automatically)